### PR TITLE
Fix unbalanced regex

### DIFF
--- a/My_expert_karyo_functions.py
+++ b/My_expert_karyo_functions.py
@@ -242,7 +242,9 @@ def detect_implicit_anomalies(anomalies):
                 implicit[an] = {"reason": "Gain/perte implicite", "ref": ref}
 
     # 3) Répétitions de la même anomalie (même chromosome)
-    base_pattern = re.compile(r'^(?:der|dic|del|dup|ins|t|i|ider|idic|r|add)\([0-9;]+\))')
+    base_pattern = re.compile(
+        r'^(?:der|dic|del|dup|ins|t|i|ider|idic|r|add)\([0-9;]+\)'
+    )
     base_map = {}
     for a in anomalies:
         norm = normalize_anomaly(a)


### PR DESCRIPTION
## Summary
- fix `base_pattern` regex in `My_expert_karyo_functions.py`

## Testing
- `python -m py_compile My_expert_karyo_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_684bf3ed8680832cb7002b5a3193a9fa