### PR TITLE
Refine scoring outputs for ISCN and Jondreville

### DIFF
--- a/My_expert_karyo_functions.py
+++ b/My_expert_karyo_functions.py
@@ -293,93 +293,98 @@ def detect_implicit_anomalies(anomalies):
     return implicit
 
 
-def calcul_scores(anomalies, clone_map):
-    """
-    Calcule les scores selon deux méthodes:
-    
-    Jondreville 2020 : 1 point par anomalie (toujours)
-    ISCN 2024     :
-      - 0 pt pour anomalies implicites (dérivés implicites & constitutionnelles)
-      - 2 pts pour déséquilibres unichr/multichr ou translocations déséquilibrées
-      - 1 pt pour anomalies standard
-    """
+def calcul_score_jondroville(anomalies):
+    """Calcule le score global selon Jondreville 2020."""
+
+    counts = Counter(anomalies)
+    total = 0
+    scores = {}
+
+    for anom in counts:
+        score = 1  # Chaque anomalie vaut 1 point
+        scores[anom] = score
+        total += score
+
+    return scores, total
+
+
+def calcul_score_iscn(anomalies, clone_map):
+    """Calcule le détail des scores selon la grille ISCN 2024."""
+
     counts = Counter(anomalies)
     norm_counts = Counter(normalize_anomaly(a) for a in anomalies)
-
     implicit_info = detect_implicit_anomalies(anomalies)
 
     rows = []
-    total_j = total_i = 0
+    total = 0
 
     for anom, cnt in counts.items():
-        score_j = 1  # Jondreville = 1 pour toutes
         norm = normalize_anomaly(anom)
         cnt_norm = norm_counts[norm]
 
         # a) Constitutionnelles (+Nc) → ISCN = 0
         if re.match(r"^\+\d+c$", norm):
-            score_i = 0
+            score = 0
             explication = "Anomalie constitutionnelle (0 point)"
 
         # b) Anomalies détectées comme implicites
         elif norm in implicit_info:
             info = implicit_info[norm]
-            score_i = 0
+            score = 0
             explication = f"{info['reason']} ({info['ref']}) (0 point)"
 
         # c) Gains/pertes simples (analyse standard si non implicite)
         elif norm.startswith(("+", "-")):
             if is_single_chr_deseq(norm, cnt_norm):
-                score_i = 2
+                score = 2
                 explication = "Déséquilibre unichromosomique (2 points)"
             elif is_complex_multichr_deseq(norm):
-                score_i = 2
+                score = 2
                 explication = "Déséquilibre multichromosomique complexe (2 points)"
             elif is_unbalanced_translocation(norm):
-                score_i = 2
+                score = 2
                 explication = "Translocation déséquilibrée (2 points)"
             else:
-                score_i = 1
+                score = 1
                 explication = "Anomalie standard (1 point)"
 
         # d) Chromosomes dicentriques → 2 points
         elif norm.startswith('dic'):
-            score_i = 2
+            score = 2
             explication = "Chromosome dicentrique (2 points)"
 
         # e) Chromosomes dérivés
         elif norm.startswith('der'):
             chroms = get_chromosomes(norm)
             if norm.count('(') == 1:
-                score_i = 2
+                score = 2
                 explication = "Chromosome dérivé non détaillé (2 points)"
             elif len(chroms) >= 2:
-                score_i = 2
+                score = 2
                 if '?' in norm:
                     explication = "Chromosome dérivé impliquant plusieurs chromosomes avec des imprécsions (2 points)"
                 else:
                     explication = "Chromosome dérivé impliquant plusieurs chromosomes (2 points)"
             else:
-                score_i = 1
+                score = 1
                 explication = "Chromosome dérivé issu du même chromosome (1 point)"
 
         # f) Toutes les autres anomalies → scoring standard
         else:
             if is_single_chr_deseq(norm, cnt_norm):
-                score_i = 2
+                score = 2
                 explication = "Déséquilibre unichromosomique (2 points)"
             elif is_complex_multichr_deseq(norm):
-                score_i = 2
+                score = 2
                 explication = "Déséquilibre multichromosomique complexe (2 points)"
             elif is_unbalanced_translocation(norm):
-                score_i = 2
+                score = 2
                 explication = "Translocation déséquilibrée (2 points)"
             else:
-                score_i = 1
+                score = 1
                 explication = "Anomalie standard (1 point)"
 
-        total_j += score_j
-        total_i += score_i
+        total += score
 
         rows.append({
             "Anomalie": anom,
@@ -387,8 +392,7 @@ def calcul_scores(anomalies, clone_map):
             "Explication": explication,
             "Occurrences": cnt,
             "Clones": ", ".join(clone_map.get(anom, [])),
-            "Score Jondreville 2020": score_j,
-            "Score ISCN 2024": score_i,
+            "Score ISCN 2024": score,
         })
 
     # Ligne de totaux
@@ -398,23 +402,28 @@ def calcul_scores(anomalies, clone_map):
         "Explication": "",
         "Occurrences": "",
         "Clones": "",
-        "Score Jondreville 2020": total_j,
-        "Score ISCN 2024": total_i,
+        "Score ISCN 2024": total,
     })
 
-    return pd.DataFrame(rows), total_i
+    return pd.DataFrame(rows), total
 
 # Fonction pour analyser une formule caryotypique
 def analyser_formule(formule):
     """
     Analyse une formule caryotypique et retourne:
     - Le DataFrame des anomalies détectées
-    - Le score total
+    - Un dictionnaire de scores totaux (ISCN et Jondreville)
     - Une erreur éventuelle
     """
     try:
         anomalies, clone_map = parse_caryotype(formule)
-        df, total = calcul_scores(anomalies, clone_map)
-        return df, total, None
+        df_iscn, total_iscn = calcul_score_iscn(anomalies, clone_map)
+        jondroville_scores, total_jondroville = calcul_score_jondroville(anomalies)
+
+        df_iscn["Score Jondreville 2020"] = df_iscn["Anomalie"].apply(
+            lambda anom: total_jondroville if anom == "TOTAL" else jondroville_scores.get(anom, 0)
+        )
+
+        return df_iscn, {"iscn": total_iscn, "jondroville": total_jondroville}, None
     except Exception as e:
-        return None, 0, f"Erreur lors de l'analyse de la formule: {str(e)}"
+        return None, {"iscn": 0, "jondroville": 0}, f"Erreur lors de l'analyse de la formule: {str(e)}"

--- a/app.py
+++ b/app.py
@@ -156,22 +156,25 @@ with tab1:
     
     if st.button("Analyser la formule", key="analyser_formule"):
         if formule:
-            df, total, error = analyser_formule(formule)
+            df, totals, error = analyser_formule(formule)
             if error:
                 st.error(error)
             else:
-                st.success(f"Nombre total d'anomalies détectées: {total}")
-                
+                st.success(
+                    f"Scores détectés — ISCN: {totals['iscn']} | Jondreville: {totals['jondroville']}"
+                )
+
                 # Affichage du tableau avec info-bulles
                 st.markdown("### Détail des anomalies")
-                
+
                 # Formatage des anomalies pour l'affichage
                 anomalies_df = df.iloc[:-1]  # Exclure la ligne TOTAL
                 anomalies_html = format_anomalies_compact(anomalies_df)
                 st.markdown(anomalies_html, unsafe_allow_html=True)
-                
+
                 # Affichage du total
-                st.markdown(f"**Score total: {total}**")
+                st.markdown(f"**Score total ISCN: {totals['iscn']}**")
+                st.markdown(f"**Score total Jondreville: {totals['jondroville']}**")
         else:
             st.warning("Veuillez entrer une formule caryotypique.")
 
@@ -220,118 +223,187 @@ with tab2:
                 # Renommer la colonne trouvée en 'Formule' pour simplifier la suite
                 if formule_col != 'Formule':
                     df_input = df_input.rename(columns={formule_col: 'Formule'})
-                # Vérifier si la colonne Count existe
-                has_count = 'Count' in df_input.columns
-                
+
+                # Détection et renommage des colonnes de référence
+                count_i_col = None
+                count_j_col = None
+                for col in df_input.columns:
+                    norm = col.strip().lower()
+                    if norm == 'count_i':
+                        count_i_col = col
+                    elif norm == 'count_j':
+                        count_j_col = col
+
+                if count_i_col and count_i_col != 'Count_i':
+                    df_input = df_input.rename(columns={count_i_col: 'Count_i'})
+                if count_j_col and count_j_col != 'Count_j':
+                    df_input = df_input.rename(columns={count_j_col: 'Count_j'})
+
+                has_count_i = 'Count_i' in df_input.columns
+                has_count_j = 'Count_j' in df_input.columns
+
+                def normalize_reference(value):
+                    if isinstance(value, str):
+                        trimmed = value.strip()
+                        if not trimmed:
+                            return None
+                        try:
+                            numeric = float(trimmed)
+                            if numeric.is_integer():
+                                return int(numeric)
+                            return numeric
+                        except ValueError:
+                            return trimmed
+                    if pd.isna(value):
+                        return None
+                    if isinstance(value, float) and value.is_integer():
+                        return int(value)
+                    return value
+
                 # Création du DataFrame de résultats
                 results = []
                 all_anomalies_details = []
+                match_details = []
 
                 for idx, row in df_input.iterrows():
                     formule_fichier = row['Formule']
-                    count_manuel = row['Count'] if has_count else None
+                    ref_iscn_value = normalize_reference(row['Count_i']) if has_count_i else None
+                    ref_jondroville_value = normalize_reference(row['Count_j']) if has_count_j else None
 
-                    df_analyse, count_auto, error = analyser_formule(formule_fichier)
-                    
+                    df_analyse, totals, error = analyser_formule(formule_fichier)
+
+                    match_detail = {"iscn": None, "jon": None}
+
                     if error:
                         anomalies_detail = error
-                        match = "❌" if has_count else "N/A"
+                        comptage_iscn = "Erreur"
+                        comptage_jondroville = "Erreur"
                         all_anomalies_details.append({"error": True, "message": error})
                     else:
                         # Extraction des détails des anomalies
                         anomalies_df = df_analyse.iloc[:-1]  # Exclure la ligne TOTAL
-                        
+
                         # Stocker les détails pour l'affichage
                         all_anomalies_details.append({"error": False, "df": anomalies_df})
-                        
+
                         # Texte simple pour l'export
                         anomalies_detail = ", ".join([
-                            f"{row['Anomalie']} ({row['Type']}): {row['Score ISCN 2024']} pts"
-                            for _, row in anomalies_df.iterrows()
+                            f"{row_detail['Anomalie']} ({row_detail['Type']}): {row_detail['Score ISCN 2024']} pts"
+                            for _, row_detail in anomalies_df.iterrows()
                         ])
-                        
-                        # Vérification de la correspondance si Count est disponible
-                        match = "✅" if has_count and count_auto == count_manuel else "❌" if has_count else "N/A"
-                    
+
+                        comptage_iscn = totals['iscn']
+                        comptage_jondroville = totals['jondroville']
+
+                        if has_count_i and ref_iscn_value is not None:
+                            match_detail['iscn'] = comptage_iscn == ref_iscn_value
+                        if has_count_j and ref_jondroville_value is not None:
+                            match_detail['jon'] = comptage_jondroville == ref_jondroville_value
+
+                    match_details.append(match_detail)
+
                     result_row = {
                         "Ligne": idx + 1,  # +1 pour ne pas inclure l'en-tête du fichier
                         "Formule": formule_fichier,
-                        "Comptage automatique": count_auto if not error else "Erreur",
+                        "Comptage ISCN": comptage_iscn,
+                        "Comptage Jon": comptage_jondroville,
                         "Anomalies détectées": anomalies_detail  # Version texte pour l'export
                     }
-                    
-                    # Ajouter le comptage manuel si disponible
-                    if has_count:
-                        result_row["Comptage manuel"] = count_manuel
-                        result_row["Correspondance"] = match
-                    
+
+                    if has_count_i:
+                        result_row["Ref ISCN"] = ref_iscn_value
+                    if has_count_j:
+                        result_row["Ref Jon"] = ref_jondroville_value
+
                     results.append(result_row)
-                
-                # Création du DataFrame de résultats
+
+                # Création du DataFrame de résultats avec un ordre de colonnes défini
                 results_df = pd.DataFrame(results)
-                
+                columns_order = ["Ligne", "Formule", "Comptage ISCN"]
+                if has_count_i:
+                    columns_order.append("Ref ISCN")
+                columns_order.append("Comptage Jon")
+                if has_count_j:
+                    columns_order.append("Ref Jon")
+                columns_order.append("Anomalies détectées")
+                results_df = results_df[columns_order]
+
+                # Fonctions utilitaires pour l'affichage
+                def format_display(value):
+                    if isinstance(value, str):
+                        return value
+                    if pd.isna(value):
+                        return "—"
+                    if isinstance(value, float) and value.is_integer():
+                        return str(int(value))
+                    return str(value)
+
+                display_config = [
+                    ("Ligne", 1),
+                    ("Formule", 3),
+                    ("Comptage ISCN", 1),
+                ]
+                if has_count_i:
+                    display_config.append(("Ref ISCN", 1))
+                display_config.append(("Comptage Jon", 1))
+                if has_count_j:
+                    display_config.append(("Ref Jon", 1))
+                display_config.append(("Anomalies détectées", 4))
+
                 # Affichage des résultats
                 st.markdown("### Résultats de l'analyse")
-                
-                # Créer un en-tête de tableau personnalisé
-                cols = st.columns([1, 3, 1, 1, 1, 4] if has_count else [1, 3, 1, 6])
-                with cols[0]:
-                    st.markdown("**Ligne**")
-                with cols[1]:
-                    st.markdown("**Formule**")
-                with cols[2]:
-                    st.markdown("**Comptage auto**")
-                if has_count:
-                    with cols[3]:
-                        st.markdown("**Comptage manuel**")
-                    with cols[4]:
-                        st.markdown("**Correspondance**")
-                with cols[-1]:
-                    st.markdown("**Anomalies détectées**")
-                
-                # Afficher chaque ligne avec un expander pour les anomalies
+
+                header_cols = st.columns([cfg[1] for cfg in display_config])
+                for col_obj, (label, _) in zip(header_cols, display_config):
+                    with col_obj:
+                        st.markdown(f"**{label}**")
+
+                # Afficher chaque ligne
                 for i, (_, row_data) in enumerate(results_df.iterrows()):
                     anomalies = all_anomalies_details[i]
+                    matches = match_details[i]
 
-                    # Créer une ligne de tableau
-                    cols = st.columns([1, 3, 1, 1, 1, 4] if has_count else [1, 3, 1, 6])
+                    line_cols = st.columns([cfg[1] for cfg in display_config])
+                    for col_obj, (label, _) in zip(line_cols, display_config):
+                        with col_obj:
+                            if label == "Comptage ISCN":
+                                text = format_display(row_data[label])
+                                if matches["iscn"] is not None:
+                                    text = f"{text} {'✅' if matches['iscn'] else '❌'}"
+                                st.markdown(text)
+                            elif label == "Comptage Jon":
+                                text = format_display(row_data[label])
+                                if matches["jon"] is not None:
+                                    text = f"{text} {'✅' if matches['jon'] else '❌'}"
+                                st.markdown(text)
+                            elif label == "Anomalies détectées":
+                                if anomalies["error"]:
+                                    st.error(anomalies["message"])
+                                else:
+                                    html = format_anomalies_compact(anomalies["df"])
+                                    st.markdown(html, unsafe_allow_html=True)
+                            else:
+                                st.markdown(format_display(row_data.get(label)))
 
-                    # Numéro de ligne
-                    with cols[0]:
-                        st.markdown(f"{row_data['Ligne']}")
-
-                    # Formule
-                    with cols[1]:
-                        st.markdown(f"{row_data['Formule']}")
-
-                    # Comptage automatique
-                    with cols[2]:
-                        st.markdown(f"{row_data['Comptage automatique']}")
-
-                    # Comptage manuel et correspondance (si disponible)
-                    if has_count:
-                        with cols[3]:
-                            st.markdown(f"{row_data['Comptage manuel']}")
-                        with cols[4]:
-                            st.markdown(f"{row_data['Correspondance']}")
-
-                    # Anomalies détectées avec expander
-                    with cols[-1]:
-                        if anomalies["error"]:
-                            st.error(anomalies["message"])
-                        else:
-                            html = format_anomalies_compact(anomalies["df"])
-                            st.markdown(html, unsafe_allow_html=True)
-                                        
-                    # Ligne de séparation
                     st.markdown("---")
-                
-                # Statistiques si Count est disponible
-                if has_count:
-                    nb_total = len(results_df)
-                    nb_match = results_df['Correspondance'].value_counts().get("✅", 0)
-                    st.success(f"Correspondance: {nb_match}/{nb_total} ({int(nb_match/nb_total*100 if nb_total else 0)}%)")
-                
+
+                # Statistiques de correspondance
+                if has_count_i or has_count_j:
+                    if has_count_i:
+                        total_i = sum(1 for m in match_details if m["iscn"] is not None)
+                        match_i = sum(1 for m in match_details if m["iscn"])
+                        if total_i:
+                            st.success(
+                                f"Correspondance ISCN: {match_i}/{total_i} ({int(match_i/total_i*100)}%)"
+                            )
+                    if has_count_j:
+                        total_j = sum(1 for m in match_details if m["jon"] is not None)
+                        match_j = sum(1 for m in match_details if m["jon"])
+                        if total_j:
+                            st.success(
+                                f"Correspondance Jondreville: {match_j}/{total_j} ({int(match_j/total_j*100)}%)"
+                            )
+
                 # Option d'export Excel
                 st.subheader("Exporter les résultats")
                 st.markdown(get_excel_download_link(results_df), unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- add dedicated helpers to compute ISCN and Jondreville totals and expose both scores from `analyser_formule`
- surface both totals in the single-formula view and normalize reference counts from Count_i / Count_j inputs
- redesign the file-analysis table to show ISCN/Jondreville auto counts beside their references with inline match icons and updated headers

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d62ee79490832cb19349750f961289